### PR TITLE
fix: network_prepare script

### DIFF
--- a/app-foundation/3-networks-extension/envs/development/boa_settings.example.tfvars
+++ b/app-foundation/3-networks-extension/envs/development/boa_settings.example.tfvars
@@ -18,7 +18,7 @@
  Tfvars for BoA shared VPC
 *****************************************/
 
-enable_hub_and_spoke              = "true"
-enable_hub_and_spoke_transitivity = "true"
-nat_enabled                       = "true"
-optional_firewall_rules_enabled   = "true"
+enable_hub_and_spoke              = true
+enable_hub_and_spoke_transitivity = true
+nat_enabled                       = true
+optional_firewall_rules_enabled   = true

--- a/app-foundation/3-networks-extension/envs/non-production/boa_settings.example.tfvars
+++ b/app-foundation/3-networks-extension/envs/non-production/boa_settings.example.tfvars
@@ -18,7 +18,7 @@
  Tfvars for BoA shared VPC
 *****************************************/
 
-enable_hub_and_spoke              = "true"
-enable_hub_and_spoke_transitivity = "true"
-nat_enabled                       = "true"
-optional_firewall_rules_enabled   = "true"
+enable_hub_and_spoke              = true
+enable_hub_and_spoke_transitivity = true
+nat_enabled                       = true
+optional_firewall_rules_enabled   = true

--- a/app-foundation/3-networks-extension/envs/production/boa_settings.example.tfvars
+++ b/app-foundation/3-networks-extension/envs/production/boa_settings.example.tfvars
@@ -18,7 +18,7 @@
  Tfvars for BoA shared VPC
 *****************************************/
 
-enable_hub_and_spoke              = "true"
-enable_hub_and_spoke_transitivity = "true"
-nat_enabled                       = "true"
-optional_firewall_rules_enabled   = "true"
+enable_hub_and_spoke              = true
+enable_hub_and_spoke_transitivity = true
+nat_enabled                       = true
+optional_firewall_rules_enabled   = true

--- a/app-foundation/3-networks-extension/envs/shared/boa_settings.example.tfvars
+++ b/app-foundation/3-networks-extension/envs/shared/boa_settings.example.tfvars
@@ -18,5 +18,5 @@
  Tfvars for BoA shared VPC
 *****************************************/
 
-enable_hub_and_spoke              = "true"
-enable_hub_and_spoke_transitivity = "true"
+enable_hub_and_spoke              = true
+enable_hub_and_spoke_transitivity = true

--- a/app-foundation/3-networks-extension/envs/shared/boa_settings.example.tfvars
+++ b/app-foundation/3-networks-extension/envs/shared/boa_settings.example.tfvars
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+ Tfvars for BoA shared VPC
+*****************************************/
+
+enable_hub_and_spoke              = "true"
+enable_hub_and_spoke_transitivity = "true"

--- a/app-foundation/3-networks-extension/network_prepare.sh
+++ b/app-foundation/3-networks-extension/network_prepare.sh
@@ -20,6 +20,8 @@ parent_dir=$( dirname "$(pwd)" )
 if [[ ! -d "$parent_dir/3-networks" ]]; then
     git clone --depth 1 --filter=blob:none https://github.com/terraform-google-modules/terraform-example-foundation example-foundation
     mv example-foundation/3-networks/ "$parent_dir"
+    mv example-foundation/build/cloudbuild-tf-* "$parent_dir"/../build
+    mv example-foundation/build/tf-wrapper.sh "$parent_dir"/../build
     rm -rf example-foundation
 fi
 if [[ ! -f "$parent_dir/3-networks/envs/development/boa_*" ]]; then


### PR DESCRIPTION
Fixes

- tfvars in each 3-networks/envs set to bools instead of strings
- Missing tfvars in 3-networks/shared
- Get the cloudbuild-tf-plan/apply and tfwrapper.sh file from build folder of example foundation, added as a step in network_prepare.sh