### PR TITLE
fix path to mesh-external-svc.yaml file to point to the transactions folder instead of frontend

### DIFF
--- a/6-anthos-install/README.md
+++ b/6-anthos-install/README.md
@@ -346,7 +346,7 @@ The changes need to be applied on the following files:
 1. Update the configuration of the external service mesh for database access. Follow the instructions in the files:
 
 - ${HOME}/bank-of-anthos-repos/root-config-repo/namespaces/boa/accounts/mesh-external-svc.yaml
-- ${HOME}/bank-of-anthos-repos/root-config-repo/namespaces/boa/frontend/mesh-external-svc.yaml
+- ${HOME}/bank-of-anthos-repos/root-config-repo/namespaces/boa/transactions/mesh-external-svc.yaml
 
 1. push the content to the root-config-repo
     ```


### PR DESCRIPTION
Fix the path to the `mesh-external-svc.yaml` file to point to the correct folder `transactions` instead of `frontend`


- [ ] Tests pass
- [x] Appropriate changes to README are included in PR
